### PR TITLE
Bug/prevent continuous requeuing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 .project
 .settings
 .tmproj
+.idea
 nbproject
 Thumbs.db
 

--- a/queues.js
+++ b/queues.js
@@ -1,9 +1,10 @@
 var queues = (function () {
 
-var amqp = require('amqplib');
-var when = require('when');
-
-var amqpUri = process.env.AMQP_URI || 'amqp://localhost';
+    var amqp = require('amqplib');
+    var when = require('when');
+    var totalMessageCount = 0;
+    var processedMessageCount = 0;
+    var amqpUri = process.env.AMQP_URI || 'amqp://localhost';
 
 // handle shutdown
 // process.once('SIGINT', function() {
@@ -14,173 +15,223 @@ var amqpUri = process.env.AMQP_URI || 'amqp://localhost';
 
 // });
 
-function createChannel(conn) {
-  console.log("connected");
-  connection = conn;
-  conn.on('error', function (err) {
-  	console.log(err);
-  });
-  return conn.createChannel();
-
-}
-
-function iterate(queue, callback, ch) {
-
-  return when.iterate(function() { return ch.get(queue); },
-    function(msg) { return msg === false; },
-    callback,
-    undefined
-    );
-
-}
-
-function parse(msg) {
-	return {
-		id: msg.fields.deliveryTag,
-		routingKey: msg.fields.routingKey,
-		properties: msg.properties,
-		content: msg.content.toString(),
-    timestamp: msg.timestamp
-	};
-}
-
-
-function listen(exchange, callback, ch) {
-
-  return ch.assertQueue(null, {autodelete: true})
-             .then(function(ok) {
-                ch.bindQueue(ok.queue, exchange, '#');
-                return ch.consume(ok.queue, function(msg) { callback(parse(msg));}, {noAck: true});
-              });
-}
-
-function disconnect() {
-  console.log("connection closed");
-  return connection.close();
-
-}
-
-function redeliver(content, exchange, routingkey) {
-
-  console.log("redelivering!");
-  return connection.createChannel()
-      .then(publish.bind(undefined, content, exchange, routingkey));
-}
-
-function publish(content, exchange, routingkey, ch) {
-  console.log("publishing to original queue");
-  ch.publish(exchange, routingkey, new Buffer(content), {'deliveryMode': 2});
-   return ch.close();
-}
-
-
-function ackIfMatches(ch, deliveryTag, msg) {
-
-  if (msg && msg.fields.deliveryTag == deliveryTag) {
-    return ch.ack(msg);
-  }
-
-}
-
-function redeliverAll(ch, msg) {
-
-  if (msg) {
-
-    var content = msg.content.toString();
-    var queue = msg.properties.headers['x-death'][0]['queue'];
-
-    ch.ack(msg);
-
-    return redeliver(content, '', queue);
-
-  }
-}
-
-function redeliverIfMatches(ch, deliveryTag, msg) {
-
-  if (msg && msg.fields.deliveryTag == deliveryTag) {
-
-    var content = msg.content.toString();
-    var queue = msg.properties.headers['x-death'][0]['queue'];
-
-    ch.ack(msg);
-
-    return redeliver(content, '', queue);
-
-  }
-
-}
-
-	return {
-
-		peek: function(queue) {
-      console.log('peeking queue ' + queue + ' on ' + amqpUri);
-      var messages = [];
-
-      return amqp.connect(amqpUri)
-				.then(createChannel)
-				.then(iterate.bind(undefined, queue, function(msg) { if (msg) messages.push(parse(msg)); } ))
-				.then(disconnect)
-				.then(function() {
-					console.log('done fetching messages');
-					return messages;
-
-				});
-
-		},
- requeueAll: function(queue) {
-      return amqp.connect(amqpUri)
-        .then(createChannel)
-        .then(
-          function(ch) {
-             return iterate(queue, redeliverAll.bind(undefined, ch), ch);
-          })
-        .delay(100)
-        .then(disconnect)
-        .then(function() {
-          console.log('done requeueing');
-          return true;
+    function createChannel(conn) {
+        console.log("connected");
+        connection = conn;
+        conn.on('error', function (err) {
+            console.log(err);
         });
-    },
-		requeue: function(queue, deliveryTag) {
+        return conn.createChannel();
 
-			return amqp.connect(amqpUri)
-				.then(createChannel)
-				.then(
-          function(ch) {
-             return iterate(queue, redeliverIfMatches.bind(undefined, ch, deliveryTag), ch);
-          })
-        .delay(100)
-				.then(disconnect)
-				.then(function() {
-					console.log('done requeueing');
-					return true;
-				});
-
-		},
-    delete: function(queue, deliveryTag) {
-
-      console.log("deleting delivery tag " + deliveryTag + " on " + queue);
-
-      return amqp.connect(amqpUri)
-        .then(createChannel)
-        .then(
-          function(ch) {
-             return iterate(queue, ackIfMatches.bind(undefined, ch, deliveryTag), ch);
-          })
-        .delay(100)
-        .then(disconnect)
-        .then(function() {
-          console.log('done deleting');
-          return true;
-        });
-    },
-    startListening: function(exchange, callback) {
-      return amqp.connect(amqpUri)
-          .then(createChannel)
-          .then(listen.bind(undefined, exchange, callback));
     }
-	};
+
+    function iterate(queue, callback, ch) {
+
+        return when.iterate(function () {
+                return ch.get(queue);
+            },
+            function (msg) {
+                return msg === false;
+            },
+            callback,
+            undefined
+        );
+
+    }
+
+    function iterateRequeue(queue, callback, ch) {
+        /*
+        f - function that, given a seed, returns the next value or a promise for it.
+        predicate - function that receives the current iteration value, and should return truthy when the iterating should stop
+        handler - function that receives each value as it is produced by f. It may return a promise to delay the next iteration.
+        seed - initial value provided to the handler, and first f invocation. May be a promise.
+        */
+        return when.iterate(function () {
+                return ch.get(queue);
+            },
+            function (msg) {
+
+                if (processedMessageCount <= totalMessageCount) {
+                    // Normal flow
+                    processedMessageCount++;
+                    return false;
+                }
+                else if(processedMessageCount > totalMessageCount)
+                {
+                    // You have reached the end of the current queue, doing a hard stop here.
+                    // New messages might have been added to the iteration while iterating.
+                    // We want to prevent that the same messages get's offered over and over again.
+                    console.log('Terminating, all messages where processed succesfully.');
+                    console.log('During this iteration new messages ended up in the dead letter queue, they will be requeued in the next run.');
+                    return true;
+                }
+                else if (msg === undefined) {
+                    // First message always seems to be undefined, continue interating.
+                    console.log('First message always seems to be undefined, continue iterating.')
+                    return false;
+                }
+                else if (msg === false) {
+                    return true;
+                }
+
+                throw new Error("Something went wrong while requeuing messages.");
+            },
+            callback,
+            undefined
+        );
+    }
+
+    function parse(msg) {
+        return {
+            id: msg.fields.deliveryTag,
+            routingKey: msg.fields.routingKey,
+            properties: msg.properties,
+            content: msg.content.toString(),
+            timestamp: msg.timestamp
+        };
+    }
+
+
+    function listen(exchange, callback, ch) {
+
+        return ch.assertQueue(null, {autodelete: true})
+            .then(function (ok) {
+                ch.bindQueue(ok.queue, exchange, '#');
+                return ch.consume(ok.queue, function (msg) {
+                    callback(parse(msg));
+                }, {noAck: true});
+            });
+    }
+
+    function disconnect() {
+        console.log("connection closed");
+        return connection.close();
+
+    }
+
+    function redeliver(content, exchange, routingkey) {
+
+        console.log("redelivering!");
+        return connection.createChannel()
+            .then(publish.bind(undefined, content, exchange, routingkey));
+    }
+
+    function publish(content, exchange, routingkey, ch) {
+        console.log("publishing to original queue");
+        ch.publish(exchange, routingkey, new Buffer(content), {'deliveryMode': 2});
+        return ch.close();
+    }
+
+
+    function ackIfMatches(ch, deliveryTag, msg) {
+
+        if (msg && msg.fields.deliveryTag == deliveryTag) {
+            return ch.ack(msg);
+        }
+
+    }
+
+    function redeliverAll(ch, msg) {
+
+        if (msg) {
+
+            var content = msg.content.toString();
+            var queue = msg.properties.headers['x-death'][0]['queue'];
+
+            ch.ack(msg);
+
+            return redeliver(content, '', queue);
+
+        }
+    }
+
+    function redeliverIfMatches(ch, deliveryTag, msg) {
+
+        if (msg && msg.fields.deliveryTag == deliveryTag) {
+
+            var content = msg.content.toString();
+            var queue = msg.properties.headers['x-death'][0]['queue'];
+
+            ch.ack(msg);
+
+            return redeliver(content, '', queue);
+        }
+    }
+
+    return {
+        setRequeueAllMessageCount: function (num_messages) {
+            totalMessageCount = num_messages;
+        },
+        peek: function (queue) {
+            console.log('peeking queue ' + queue + ' on ' + amqpUri);
+            var messages = [];
+
+            return amqp.connect(amqpUri)
+                .then(createChannel)
+                .then(iterate.bind(undefined, queue, function (msg) {
+                    if (msg) messages.push(parse(msg));
+                }))
+                .then(disconnect)
+                .then(function () {
+                    console.log('done fetching messages');
+                    return messages;
+
+                });
+
+        },
+        requeueAll: function (queue) {
+            return amqp.connect(amqpUri)
+                .then(createChannel)
+                .then(
+                    function (ch) {
+                        return iterateRequeue(queue, redeliverAll.bind(undefined, ch), ch);
+                    })
+                .delay(100)
+                .then(disconnect)
+                .then(function () {
+                    console.log('done requeueing');
+                    return true;
+                });
+        },
+        requeue: function (queue, deliveryTag) {
+
+            return amqp.connect(amqpUri)
+                .then(createChannel)
+                .then(
+                    function (ch) {
+                        return iterate(queue, redeliverIfMatches.bind(undefined, ch, deliveryTag), ch);
+                    })
+                .delay(100)
+                .then(disconnect)
+                .then(function () {
+                    console.log('done requeueing');
+                    return true;
+                });
+
+        },
+        delete: function (queue, deliveryTag) {
+
+            console.log("deleting delivery tag " + deliveryTag + " on " + queue);
+
+            return amqp.connect(amqpUri)
+                .then(createChannel)
+                .then(
+                    function (ch) {
+                        return iterate(queue, ackIfMatches.bind(undefined, ch, deliveryTag), ch);
+                    })
+                .delay(100)
+                .then(disconnect)
+                .then(function () {
+                    console.log('done deleting');
+                    return true;
+                });
+        },
+        startListening: function (exchange, callback) {
+            return amqp.connect(amqpUri)
+                .then(createChannel)
+                .then(listen.bind(undefined, exchange, callback));
+        }
+    };
 }());
 
-module.exports =  queues;
+module.exports = queues;

--- a/queues.js
+++ b/queues.js
@@ -2,17 +2,16 @@ var queues = (function () {
 
     var amqp = require('amqplib');
     var when = require('when');
+    var amqpUri = process.env.AMQP_URI || 'amqp://localhost';
+
     var totalMessageCount = 0;
     var processedMessageCount = 0;
-    var amqpUri = process.env.AMQP_URI || 'amqp://localhost';
 
 // handle shutdown
 // process.once('SIGINT', function() {
-
 // 	// console.log("Disconnecting from RabbitMQ");
 // 	// conn.close();
 // 	// console.log("amqp connection closed");
-
 // });
 
     function createChannel(conn) {
@@ -22,11 +21,9 @@ var queues = (function () {
             console.log(err);
         });
         return conn.createChannel();
-
     }
 
     function iterate(queue, callback, ch) {
-
         return when.iterate(function () {
                 return ch.get(queue);
             },
@@ -36,7 +33,6 @@ var queues = (function () {
             callback,
             undefined
         );
-
     }
 
     function iterateRequeue(queue, callback, ch) {
@@ -60,14 +56,13 @@ var queues = (function () {
                 {
                     // You have reached the end of the current queue, doing a hard stop here.
                     // New messages might have been added to the iteration while iterating.
-                    // We want to prevent that the same messages get's offered over and over again.
+                    // We want to prevent that the same message get's offered over and over again.
                     console.log('Terminating, all messages where processed succesfully.');
                     console.log('During this iteration new messages ended up in the dead letter queue, they will be requeued in the next run.');
                     return true;
                 }
                 else if (msg === undefined) {
-                    // First message always seems to be undefined, continue interating.
-                    console.log('First message always seems to be undefined, continue iterating.')
+                    // First message always seems to be undefined, just continue interating.
                     return false;
                 }
                 else if (msg === false) {

--- a/requeueall.js
+++ b/requeueall.js
@@ -1,7 +1,9 @@
 var queues = require('./queues');
 
+var messageCount = 0;
 queues.peek('failed.dead').then(function(messages) {
 
+    queues.setRequeueAllMessageCount(messages.length);
 	console.log('found ' + messages.length + ' messages');
 
 	if (messages.length < 1)

--- a/requeueall.js
+++ b/requeueall.js
@@ -3,6 +3,7 @@ var queues = require('./queues');
 var messageCount = 0;
 queues.peek('failed.dead').then(function(messages) {
 
+	console.log(messages);
     queues.setRequeueAllMessageCount(messages.length);
 	console.log('found ' + messages.length + ' messages');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | n/a
| Related PR    | n/a
| Fixed issues  | DEV-369

While requeuing messages from the dead letter queue, new messages that arrived in the dead letter queue during processing where added to the list of messages that needed to be processed during the current cycle. This caused messages to be redelivered multiple times within a single iteration. This fix prevents the process from processing more messages then there where in the queue initially, blocking this behavior.